### PR TITLE
Change Quasar default dev port to 8080

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -101,7 +101,7 @@ module.exports = configure(function (ctx) {
     // Full list of options: https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-devServer
     devServer: {
       https: false,
-      port: 80,
+      port: 8080,
       open: true // opens browser window automatically
     },
 


### PR DESCRIPTION
Port 80 is only allowed for the root user by default in Linux (and we don't want to use sudo), so the default configuration leads to an error with `quasar dev`:

```
 App • ⚠️  Unknown network error occurred
Error: listen EACCES: permission denied 0.0.0.0:80
    at Server.setupListenHandle [as _listen2] (node:net:1855:21)
    at listenInCluster (node:net:1920:12)
    at doListen (node:net:2069:7)
    at process.processTicksAndRejections (node:internal/process/task_queues:83:21) {
  code: 'EACCES',
  errno: -13,
  syscall: 'listen',
  address: '0.0.0.0',
  port: 80
}
```

This PR changes the port to 8080 which non-root users are allowed to open.