### PR TITLE
Silence nginx verbose entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ COPY docker-entrypoint.d/* /docker-entrypoint.d/
 RUN chmod u+x /docker-entrypoint.d/*.sh
 
 EXPOSE 80
+ENV NGINX_ENTRYPOINT_QUIET_LOGS=1
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
As specified in <https://hub.docker.com/_/nginx>:

> Since version 1.19.0, a verbose entrypoint was added. It provides information on what's happening during container startup. You can silence this output by setting environment variable NGINX_ENTRYPOINT_QUIET_LOGS:

Silences the following messages, which make it harder to see real problems in the docker compose output.
Part of the larger effort to make the Docker Compose logs easier to parse in <https://github.com/Onto-Med/top-deployment/issues/44>.

```
frontend-1  | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
frontend-1  | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
frontend-1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/00-copy-files.sh
frontend-1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/01-set-env-vars.sh
frontend-1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
frontend-1  | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
frontend-1  | 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf differs from the packaged version
frontend-1  | /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
frontend-1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
frontend-1  | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
frontend-1  | /docker-entrypoint.sh: Configuration complete; ready for start up
```