### PR TITLE
Hide repository test button in some cases

### DIFF
--- a/src/pages/Editor.vue
+++ b/src/pages/Editor.vue
@@ -25,6 +25,7 @@
                 <q-icon name="sync_alt" class="rotate-90" />
               </q-btn>
               <q-btn
+                v-if="writable && !isConceptRepository"
                 dense
                 :title="t('testThing', { thing: t('repository') })"
                 @click="showTestDialog()"


### PR DESCRIPTION
- For concept repositories
- For users without write permission